### PR TITLE
Pointer is misnamed

### DIFF
--- a/SSKeychain.m
+++ b/SSKeychain.m
@@ -124,7 +124,7 @@ CFTypeRef SSKeychainAccessibilityType = NULL;
 		
 #if __IPHONE_4_0 && TARGET_OS_IPHONE
 		if (SSKeychainAccessibilityType) {
-			[dictionary setObject:(id)[self accessibilityType] forKey:(id)kSecAttrAccessible];
+			[query setObject:(id)[self accessibilityType] forKey:(id)kSecAttrAccessible];
 		}
 #endif
 		


### PR DESCRIPTION
The `query` pointer is misnamed as `dictionary`. This causes compilation to fail on iOS.
