### PR TITLE
Update Podspec to reflect build target requirements

### DIFF
--- a/SSKeychain.podspec
+++ b/SSKeychain.podspec
@@ -9,5 +9,7 @@ Pod::Spec.new do |s|
   s.source_files = 'SSKeychain/*.{h,m}'
   s.frameworks   = 'Security'
   s.requires_arc = true
+  s.ios.deployment_target = '6.0'
+  s.osx.deployment_target = '10.8'
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
 end


### PR DESCRIPTION
NSSecureCoding protocol is only available on OSX 10.8 and iOS 6.0

Update the spec to reflect those as target requirements.

Addresses this Issue

https://github.com/soffes/sskeychain/issues/30
