### PR TITLE
Fixed memory leak

### DIFF
--- a/SSKeychain/SSKeychainQuery.m
+++ b/SSKeychain/SSKeychainQuery.m
@@ -98,7 +98,7 @@
 		return nil;
 	}
 
-    return (__bridge NSArray *)result;
+    return (__bridge_transfer NSArray *)result;
 }
 
 


### PR DESCRIPTION
Fixed memory leak by making sure NSArray ownership is transfered back to ARC
