### PR TITLE
iCloud Keychain Support

### DIFF
--- a/SSKeychain/SSKeychainQuery.h
+++ b/SSKeychain/SSKeychainQuery.h
@@ -28,6 +28,11 @@
 @property (nonatomic, copy) NSString *accessGroup;
 #endif
 
+#if __IPHONE_7_0 || __MAC_10_9
+/** kSecAttrSynchronizable */
+@property (nonatomic, getter = isSynchronizable) BOOL synchronizable;
+#endif
+
 /** Root storage for password information */
 @property (nonatomic, copy) NSData *passwordData;
 

--- a/SSKeychain/SSKeychainQuery.m
+++ b/SSKeychain/SSKeychainQuery.m
@@ -20,6 +20,9 @@
 @synthesize accessGroup = _accessGroup;
 #endif
 
+#if __IPHONE_7_0 || __MAC_10_9
+@synthesize synchronizable = _synchronizable;
+#endif
 
 #pragma mark - Public
 
@@ -175,6 +178,12 @@
         [dictionary setObject:self.accessGroup forKey:(__bridge id)kSecAttrAccessGroup];
     }
 #endif
+#endif
+    
+#if __IPHONE_7_0 || __MAC_10_9
+    if (self.isSynchronizable) {
+        [dictionary setObject:@YES forKey:(__bridge id)(kSecAttrSynchronizable)];
+    }
 #endif
 
     return dictionary;


### PR DESCRIPTION
Added `kSecAttrSynchronizable` support to `SSKeychainQuery`. Since I didn't want to break the public API of `SSKeychain` itself or add more methods to that class, I thought this was the cleanest approach.

Original code by @bcapps for a @Lickability project.
