### PR TITLE
fix a memory leak

### DIFF
--- a/SSKeychain/SSKeychainQuery.m
+++ b/SSKeychain/SSKeychainQuery.m
@@ -101,7 +101,7 @@
 		return nil;
 	}
 
-    return (__bridge NSArray *)result;
+    return (__bridge_transfer NSArray *)result;
 }
 
 


### PR DESCRIPTION
-[SSKeychainQuery fetchAll:] returns a object with no ownership.
This will cause memory leak.
