### PR TITLE
Default SSKeychainQuerySynchronizationMode to Any

### DIFF
--- a/SSKeychain/SSKeychainQuery.h
+++ b/SSKeychain/SSKeychainQuery.h
@@ -20,9 +20,9 @@
 #ifdef SSKEYCHAIN_SYNCHRONIZABLE_AVAILABLE
 typedef enum {
   
+  SSKeychainQuerySynchronizationModeAny,
   SSKeychainQuerySynchronizationModeNo,
 	SSKeychainQuerySynchronizationModeYes,
-  SSKeychainQuerySynchronizationModeAny,
   
 } SSKeychainQuerySynchronizationMode;
 #endif

--- a/Tests/SSKeychainTests.m
+++ b/Tests/SSKeychainTests.m
@@ -163,6 +163,27 @@ static NSString *kSSToolkitTestsLabel = @"SSToolkitLabel";
 #endif
 }
 
+- (void)testSSKeychainWithSync {
+    SSKeychainQuery *query = nil;
+    NSError *error = nil;
+    
+    // create a new keychain item with a synced password
+    query = [[SSKeychainQuery alloc] init];
+    query.password = kSSToolkitTestsPassword;
+    query.service = kSSToolkitTestsServiceName;
+    query.account = kSSToolkitTestsAccountName;
+    query.label = kSSToolkitTestsLabel;
+    query.synchronizationMode = SSKeychainQuerySynchronizationModeYes;
+    XCTAssertTrue([query save:&error], @"Unable to save item: %@", error);
+    
+    // check all accounts
+    XCTAssertTrue([self _accounts:[SSKeychain allAccounts] containsAccountWithName:kSSToolkitTestsAccountName], @"Matching account was not returned");
+    // check account
+    XCTAssertTrue([self _accounts:[SSKeychain accountsForService:kSSToolkitTestsServiceName] containsAccountWithName:kSSToolkitTestsAccountName], @"Matching account was not returned");
+    // delete password
+    XCTAssertTrue([SSKeychain deletePasswordForService:kSSToolkitTestsServiceName account:kSSToolkitTestsAccountName error:&error], @"Unable to delete password: %@", error);
+}
+
 
 #pragma mark - Private
 


### PR DESCRIPTION
`SSKeychain` class methods do not work with synced passwords.

Create a keychain item with a synced password. Now invoke `SSKeychain`
class methods like `deletePasswordForService:account:` or
`accountsForService:`. They will fail because the `SSKeychainQuery`
object they initialize internally uses the
`SSKeychainQuerySynchronizationModeNo` default.

Defaulting to `SSKeychainQuerySynchronizationModeAny` ensures the
queries created by `SSKeychain` class methods will still match as
expected.
