### PR TITLE
WIP first pass fix for iOS < 7 support

### DIFF
--- a/SSKeychain/SSKeychainQuery.h
+++ b/SSKeychain/SSKeychainQuery.h
@@ -9,23 +9,12 @@
 #import <Foundation/Foundation.h>
 #import <Security/Security.h>
 
-#ifdef __IPHONE_7_0
-	#define SSKEYCHAIN_SYNCHRONIZABLE_AVAILABLE 1
-#endif
-
-#ifdef __MAC_10_9
-	#define SSKEYCHAIN_SYNCHRONIZABLE_AVAILABLE 1
-#endif
-
-#ifdef SSKEYCHAIN_SYNCHRONIZABLE_AVAILABLE
-typedef enum {
-  
-  SSKeychainQuerySynchronizationModeNo,
-	SSKeychainQuerySynchronizationModeYes,
-  SSKeychainQuerySynchronizationModeAny,
-  
+typedef enum : NSUInteger {
+    SSKeychainQuerySynchronizationModeNo = 0,
+    SSKeychainQuerySynchronizationModeYes,
+    SSKeychainQuerySynchronizationModeAny,
+    SSKeychainQuerySynchronizationModeNotAvailable = NSNotFound
 } SSKeychainQuerySynchronizationMode;
-#endif
 
 /**
  Simple interface for querying or modifying keychain items.
@@ -46,10 +35,8 @@ typedef enum {
 @property (nonatomic, copy) NSString *accessGroup;
 #endif
 
-#ifdef SSKEYCHAIN_SYNCHRONIZABLE_AVAILABLE
 /** kSecAttrSynchronizable */
 @property (nonatomic) SSKeychainQuerySynchronizationMode synchronizationMode;
-#endif
 
 /** Root storage for password information */
 @property (nonatomic, copy) NSData *passwordData;


### PR DESCRIPTION
## action items
- [ ] support for MacOS < 10.9
- [ ] what to do about `setSynchronizationMode:` when keychain sync is not supported
## motivation

builds on the work of @Eugene-Gubin PR https://github.com/soffes/sskeychain/pull/60

The current fix for iOS < 7 leaves the `SSKEYCHAIN_SYNCHRONIZABLE_AVAILABLE` in a bad state; it can be 1 when synchronization is not available.

It also breaks MacOS support - unguarded call to `[UIDevice currentDevice]`

It does the _right_ thing with respect to restricting access to `kSecAttrSynchronizable` for iOS < 7.  I did a bunch of testing and found that on iOS 6 (somehow) `kSecAttrSynchronizable` was allowed although it did not appear in any headers.

The fix implements the strategy I mentioned here: https://github.com/soffes/sskeychain/issues/56

This fix clashes (violently?) with the style and conventions of the original source - it is a pragmatic solution, not a pretty one.

I am willing to iterate on it until it is a good shape.

Thanks @soffes and the other maintainers for your hard work!

PS:  The XCTests were all broken when I pulled from master.  Is this expected?  (Xcode 5.0.2, iPad 4 iOS 7.0.4)
