### PR TITLE
If item exists, update on save, rather than delete and re-add

### DIFF
--- a/SSKeychain/SSKeychainQuery.m
+++ b/SSKeychain/SSKeychainQuery.m
@@ -34,21 +34,37 @@
 		}
 		return NO;
 	}
-
-	[self deleteItem:nil];
-
-	NSMutableDictionary *query = [self query];
-	[query setObject:self.passwordData forKey:(__bridge id)kSecValueData];
-	if (self.label) {
-		[query setObject:self.label forKey:(__bridge id)kSecAttrLabel];
-	}
+    
+    
+    NSMutableDictionary *query = [self query];
+    status = SecItemCopyMatching((__bridge CFDictionaryRef)(query), NULL);
+    if(status == errSecSuccess){
+		NSMutableDictionary *updateAttrs = [NSMutableDictionary new];
+		[updateAttrs setObject:self.passwordData forKey:(__bridge id)kSecValueData];
+		if(self.label){
+			[updateAttrs setObject:self.label forKey:(__bridge id)kSecAttrLabel];
+		}
+		if(query[(__bridge id)(kSecAttrSynchronizable)]){
+			[updateAttrs setObject:query[(__bridge id)(kSecAttrSynchronizable)]
+							 forKey:(__bridge id)(kSecAttrSynchronizable)];
+		}
+		[query removeObjectForKey:(__bridge id)(kSecAttrSynchronizable)];
+        status = SecItemUpdate((__bridge CFDictionaryRef)(query),
+                               (__bridge CFDictionaryRef)updateAttrs);
+    }
+    else{
+        [query setObject:self.passwordData forKey:(__bridge id)kSecValueData];
+        if (self.label) {
+            [query setObject:self.label forKey:(__bridge id)kSecAttrLabel];
+        }
 #if __IPHONE_4_0 && TARGET_OS_IPHONE
-	CFTypeRef accessibilityType = [SSKeychain accessibilityType];
-	if (accessibilityType) {
-		[query setObject:(__bridge id)accessibilityType forKey:(__bridge id)kSecAttrAccessible];
-	}
+        CFTypeRef accessibilityType = [SSKeychain accessibilityType];
+        if (accessibilityType) {
+            [query setObject:(__bridge id)accessibilityType forKey:(__bridge id)kSecAttrAccessible];
+        }
 #endif
-	status = SecItemAdd((__bridge CFDictionaryRef)query, NULL);
+        status = SecItemAdd((__bridge CFDictionaryRef)query, NULL);
+    }
 
 	if (status != errSecSuccess && error != NULL) {
 		*error = [[self class] errorWithCode:status];


### PR DESCRIPTION
Deleting and readding the keychain was causing me some strange behavior, such as not being able to find the new values immediately.  It may have been an issue with security caching entitlements, regardless this fixed it for me.

There's one bit of code at line 51 where the kSecAttrSynchronizable is removed from the query,
 if you don't do this SecItemUpdate will work fine, and update the keychain attars correctly, but will still return a status of -34018.

This may clear up issues discussed in #52.
