### PR TITLE
Fix issue with NULL error param in fetch: method.

### DIFF
--- a/SSKeychain/SSKeychainQuery.m
+++ b/SSKeychain/SSKeychainQuery.m
@@ -120,8 +120,10 @@
 	[query setObject:(__bridge id)kSecMatchLimitOne forKey:(__bridge id)kSecMatchLimit];
 	status = SecItemCopyMatching((__bridge CFDictionaryRef)query, &result);
 
-	if (status != errSecSuccess && error != NULL) {
-		*error = [[self class] errorWithCode:status];
+	if (status != errSecSuccess) {
+		if (error) {
+			*error = [[self class] errorWithCode:status];
+		}
 		return NO;
 	}
 

--- a/Tests/SSKeychainTests.m
+++ b/Tests/SSKeychainTests.m
@@ -78,7 +78,6 @@ static NSString *const kSSKeychainLabel = @"SSToolkitLabel";
 	XCTAssertEqualObjects(query.passwordObject, dictionary, @"Passwords were not equal");
 }
 
-
 - (void)testMissingInformation {
 	SSKeychainQuery *query = [[SSKeychainQuery alloc] init];
 	query.service = kSSKeychainServiceName;
@@ -97,7 +96,6 @@ static NSString *const kSSKeychainLabel = @"SSToolkitLabel";
 	query.service = kSSKeychainServiceName;
 	XCTAssertFalse([query save:&error], @"Function save should return NO if not all needed information is provided: %@", error);
 }
-
 
 - (void)testDeleteWithMissingInformation {
 	SSKeychainQuery *query = [[SSKeychainQuery alloc] init];
@@ -118,6 +116,10 @@ static NSString *const kSSKeychainLabel = @"SSToolkitLabel";
 	query = [[SSKeychainQuery alloc] init];
 	query.service = kSSKeychainServiceName;
 	XCTAssertFalse([query fetch:&error], @"Function fetch should return NO if not all needed information is provided: %@", error);
+
+	query = [[SSKeychainQuery alloc] init];
+	query.service = kSSKeychainServiceName;
+	XCTAssertFalse([query fetch:NULL], @"Function fetch should return NO if not all needed information is provided and error is NULL");
 }
 
 
@@ -136,7 +138,9 @@ static NSString *const kSSKeychainLabel = @"SSToolkitLabel";
 	query.account = kSSKeychainAccountName;
 	query.password = nil;
 	query.synchronizationMode = SSKeychainQuerySynchronizationModeNo;
-	XCTAssertFalse([query fetch:&error], @"Fetch should fail when trying to fetch an unsynced password that was saved as synced.");
+	XCTAssertFalse([query fetch:&error], @"Fetch should fail when trying to fetch an unsynced password that was saved as synced: %@", error);
+	XCTAssertFalse([query fetch:NULL], @"Fetch should fail when trying to fetch an unsynced password that was saved as synced. error == NULL");
+
 	XCTAssertNotEqualObjects(query.password, kSSKeychainPassword, @"Passwords should not be equal when trying to fetch an unsynced password that was saved as synced.");
   
 	query = [[SSKeychainQuery alloc] init];


### PR DESCRIPTION
There was a case where the method would return YES if there was an
errSecSucces result from the SecItemCopyMatching() functeiona call, but
the error parameter was NULL.

Updated tests to cover this code path.
