### PR TITLE
Fix crash when SAMKeychainQuery is subclassed

### DIFF
--- a/Sources/SAMKeychainQuery.m
+++ b/Sources/SAMKeychainQuery.m
@@ -251,7 +251,7 @@
 	static dispatch_once_t onceToken;
 	static NSBundle *resourcesBundle = nil;
 	dispatch_once(&onceToken, ^{
-		NSURL *url = [[NSBundle bundleForClass:[self class]] URLForResource:@"SAMKeychain" withExtension:@"bundle"];
+		NSURL *url = [[NSBundle bundleForClass:[SAMKeychainQuery class]] URLForResource:@"SAMKeychain" withExtension:@"bundle"];
 		resourcesBundle = [NSBundle bundleWithURL:url];
 	});
 	


### PR DESCRIPTION
When SAMKeychainQuery is subclassed (I do this to work around some limitations — application-specific tweaks that don't seem appropriate for the whole project), and an error occurs, the app will crash — when using CocoaPods with frameworks enabled.

The reason why is that `[NSBundle bundleForClass:[self class]]` called in the object of a subclass will return the app bundle, instead of the SAMKeychain.framework bundle.

By explicitly using `[NSBundle bundleForClass:[SAMKeychainQuery class]]`, we're ensuring we're actually fetching the `SAMKeychain.bundle` from `SAMKeychain.framework` (or the app bundle if we're _not_ using frameworks in CocoaPods)