### PR TITLE
use relative header

### DIFF
--- a/Sources/SAMKeychain.h
+++ b/Sources/SAMKeychain.h
@@ -200,4 +200,4 @@ extern NSString *const kSAMKeychainWhereKey;
 
 NS_ASSUME_NONNULL_END
 
-#import <SAMKeychain/SAMKeychainQuery.h>
+#import "SAMKeychainQuery.h"


### PR DESCRIPTION
so that it works in both cocoapods and other cases where source is copied e.g. submodules