### PR TITLE
Import failure when using manual install

### DIFF
--- a/Sources/SAMKeychain.h
+++ b/Sources/SAMKeychain.h
@@ -200,4 +200,4 @@ extern NSString *const kSAMKeychainWhereKey;
 
 NS_ASSUME_NONNULL_END
 
-#import <SAMKeychain/SAMKeychainQuery.h>
+#import "SAMKeychainQuery.h"


### PR DESCRIPTION
When using manual installation (e.g. copying files into project or using submodules), `#import <SAMKeychain/SAMKeychainQuery.h>` in SAMKeychain.h fails with "File not found".