### PR TITLE
Add ability to specific accessibility on a per-item basis

### DIFF
--- a/Sources/SAMKeychainQuery.h
+++ b/Sources/SAMKeychainQuery.h
@@ -53,6 +53,9 @@ typedef NS_ENUM(NSUInteger, SAMKeychainQuerySynchronizationMode) {
 @property (nonatomic, copy, nullable) NSString *accessGroup;
 #endif
 
+/** kSecAttrAccessible (only used on iOS) */
+@property (nonatomic, copy, nullable) NSString *accessibility;
+
 #ifdef SAMKEYCHAIN_SYNCHRONIZATION_AVAILABLE
 /** kSecAttrSynchronizable */
 @property (nonatomic) SAMKeychainQuerySynchronizationMode synchronizationMode;

--- a/Sources/SAMKeychainQuery.m
+++ b/Sources/SAMKeychainQuery.m
@@ -41,7 +41,7 @@
 		query = [[NSMutableDictionary alloc]init];
 		[query setObject:self.passwordData forKey:(__bridge id)kSecValueData];
 #if __IPHONE_4_0 && TARGET_OS_IPHONE
-		CFTypeRef accessibilityType = [SAMKeychain accessibilityType];
+		CFTypeRef accessibilityType = self.accessibility ? (__bridge CFTypeRef)self.accessibility : [SAMKeychain accessibilityType];
 		if (accessibilityType) {
 			[query setObject:(__bridge id)accessibilityType forKey:(__bridge id)kSecAttrAccessible];
 		}
@@ -54,7 +54,7 @@
 		}
 		[query setObject:self.passwordData forKey:(__bridge id)kSecValueData];
 #if __IPHONE_4_0 && TARGET_OS_IPHONE
-		CFTypeRef accessibilityType = [SAMKeychain accessibilityType];
+		CFTypeRef accessibilityType = self.accessibility ? (__bridge CFTypeRef)self.accessibility : [SAMKeychain accessibilityType];
 		if (accessibilityType) {
 			[query setObject:(__bridge id)accessibilityType forKey:(__bridge id)kSecAttrAccessible];
 		}


### PR DESCRIPTION
We may want to change the accessibility of a given keychain item. However, the only way to do this currently with SAMKeychain is to use the class method `[SAMKeychain accessibilityType]`. This has two drawbacks:
- It sets the accessibility type for all the subsequent password saves
- If you want to change the accessibility type for a single save, you can rely on setting the global accessibility type because it wouldn't be thread-safe.

This PR adds an `accessibility` field on the SAMKeychainQuery. It doesn't otherwise change the API and stays backward compatible.