### PR TITLE
Update watchos deployment target for Xcode 10

### DIFF
--- a/SAMKeychain.xcodeproj/project.pbxproj
+++ b/SAMKeychain.xcodeproj/project.pbxproj
@@ -824,6 +824,7 @@
 				TARGETED_DEVICE_FAMILY = 4;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 3.0;
 			};
 			name = Debug;
 		};
@@ -855,6 +856,7 @@
 				TARGETED_DEVICE_FAMILY = 4;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 3.0;
 			};
 			name = Test;
 		};
@@ -886,6 +888,7 @@
 				TARGETED_DEVICE_FAMILY = 4;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 3.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Hi,
This PR is for Xcode 10 compatible.

In Xcode 10 (GM or later), We need to update watchOS Deployment Target version to 3.0 or later.
While using 2.0, We can build ipa but can't submit to App Store.

Same issue is discussed in Forum:
https://forums.developer.apple.com/thread/108408

Thanks!